### PR TITLE
Fix non-unique error at useradd command

### DIFF
--- a/provisioning/provision-user.sh
+++ b/provisioning/provision-user.sh
@@ -20,7 +20,7 @@ done
 
 if ! id -u $NEW_USER &>/dev/null; then
     echo "Creating user $NEW_USER"
-    useradd --groups admin --shell /bin/bash --uid $NEW_USER_UID $NEW_USER
+    useradd --groups admin --shell /bin/bash --non-unique --uid $NEW_USER_UID $NEW_USER
 fi
 
 NEW_USER_HOMEDIR=$(sudo -H -u $NEW_USER -s eval 'echo $HOME')


### PR DESCRIPTION
If run script from non-root user provisioning of VM will fail
due to failed creation of user (non-unique UUID).

This patch correct useradd command by --non-unique option.
